### PR TITLE
Patch-ensemblVersion-only-required-for-approach2

### DIFF
--- a/RNAseq/Workflow_Documentation/NF_RCP-F/workflow_code/NF_RCP-F_1.0.0/config/tests/test_glds194.config
+++ b/RNAseq/Workflow_Documentation/NF_RCP-F/workflow_code/NF_RCP-F_1.0.0/config/tests/test_glds194.config
@@ -4,42 +4,12 @@ params {
   Parameters that MUST be supplied
   */
   gldsAccession = 'GLDS-194' // GeneLab Data Accession Number, e.g. GLDS-104
-  ensemblVersion = 96 // ensembl version to use for reference genome, should work as far back as ensembl 80, TODO: replace with source non-specific name
-  ref_source = 'ensembl' // designates the source of the reference files, e.g. ensembl, ensembl_plants
   use_dummy_gene_counts = true // Use random gene counts for Deseq2, this addresses an issue where low/zero gene counts causes DGE analysis to fail
-
-  /*
-  Parameters that CAN be overwritten
-  */
-  runsheetPath = false
-  referenceStorePath = './References' // dicates where the reference fasta, gtf, these are shared across processing runs
-  derivedStorePath = './DerivedReferences' // dicates where the derived references files such as built index files are stored, shared across processing runs
-  outputDir = "." // the location for the output from the pipeline (also includes raw data and metadata)
-  publish_dir_mode = "link" // method for creating publish directory.  Default here for hardlink
-
-  // can be set to the path of a local gtf and fasta
-  ref_fasta = null
-  ref_gtf = null
 
   /*
   DEBUG parameters, should NOT be overwritten for production processing runs
   */
   genomeSubsample = 19 // Subsamples the reference fasta and gtf to a single sequence (often representing a single chromosome)
   truncateTo = 300 // Subsamples the raw reads files to the specified number of reads for EACH raw reads file.
-  limitSamplesTo = false // Limits the number of samples to process.  This currently is incompatible with running the DESeq2 task which requires all samples 
-  stageLocal = true // Indicates if the raw read files should be staged for processing. Disabling is useful for checking the metadata staging without running any actual data processing.
-  skipVV = false // if true, VV will not be performed
-  force_single_end = false
 
-  multiqcConfig = "${projectDir}/config/modules/multiqc.config"
-
-  quality {
-    rseqc_sample_count = 15000000
-  }
-
-  // Print help menu
-  // Should only be overridden at CLI
-  help = false
-
-  // For now, this particular is good for all organisms listed on the file.
 }

--- a/RNAseq/Workflow_Documentation/NF_RCP-F/workflow_code/NF_RCP-F_1.0.0/config/tests/test_glds207.config
+++ b/RNAseq/Workflow_Documentation/NF_RCP-F/workflow_code/NF_RCP-F_1.0.0/config/tests/test_glds207.config
@@ -4,42 +4,8 @@ params {
   Parameters that MUST be supplied
   */
   gldsAccession = 'GLDS-207' // GeneLab Data Accession Number, e.g. GLDS-104
-  ensemblVersion = 101 // ensembl version to use for reference genome, should work as far back as ensembl 80, TODO: replace with source non-specific name
-  ref_source = 'ensembl' // designates the source of the reference files, e.g. ensembl, ensembl_plants
   use_dummy_gene_counts = true // Use random gene counts for Deseq2, this addresses an issue where low/zero gene counts causes DGE analysis to fail
 
-  /*
-  Parameters that CAN be overwritten
-  */
-  runsheetPath = false
-  referenceStorePath = './References' // dicates where the reference fasta, gtf, these are shared across processing runs
-  derivedStorePath = './DerivedReferences' // dicates where the derived references files such as built index files are stored, shared across processing runs
-  outputDir = "." // the location for the output from the pipeline (also includes raw data and metadata)
-  publish_dir_mode = "link" // method for creating publish directory.  Default here for hardlink
-
-  // can be set to the path of a local gtf and fasta
-  ref_fasta = null
-  ref_gtf = null
-
-  /*
-  DEBUG parameters, should NOT be overwritten for production processing runs
-  */
-  genomeSubsample = null // Subsamples the reference fasta and gtf to a single sequence (often representing a single chromosome)
   truncateTo = 100 // Subsamples the raw reads files to the specified number of reads for EACH raw reads file.
-  limitSamplesTo = false // Limits the number of samples to process.  This currently is incompatible with running the DESeq2 task which requires all samples 
-  stageLocal = true // Indicates if the raw read files should be staged for processing. Disabling is useful for checking the metadata staging without running any actual data processing.
-  skipVV = false // if true, VV will not be performed
-  force_single_end = false
 
-  multiqcConfig = "${projectDir}/config/modules/multiqc.config"
-
-  quality {
-    rseqc_sample_count = 15000000
-  }
-
-  // Print help menu
-  // Should only be overridden at CLI
-  help = false
-
-  // For now, this particular is good for all organisms listed on the file.
 }

--- a/RNAseq/Workflow_Documentation/NF_RCP-F/workflow_code/NF_RCP-F_1.0.0/config/tests/test_glds251.config
+++ b/RNAseq/Workflow_Documentation/NF_RCP-F/workflow_code/NF_RCP-F_1.0.0/config/tests/test_glds251.config
@@ -4,42 +4,9 @@ params {
   Parameters that MUST be supplied
   */
   gldsAccession = 'GLDS-251' // GeneLab Data Accession Number, e.g. GLDS-104
-  ensemblVersion = 44 // ensembl version to use for reference genome, should work as far back as ensembl 80, TODO: replace with source non-specific name
-  ref_source = 'ensembl_plants' // designates the source of the reference files, e.g. ensembl, ensembl_plants
   use_dummy_gene_counts = true // Use random gene counts for Deseq2, this addresses an issue where low/zero gene counts causes DGE analysis to fail
 
-  /*
-  Parameters that CAN be overwritten
-  */
-  runsheetPath = false
-  referenceStorePath = './References' // dicates where the reference fasta, gtf, these are shared across processing runs
-  derivedStorePath = './DerivedReferences' // dicates where the derived references files such as built index files are stored, shared across processing runs
-  outputDir = "." // the location for the output from the pipeline (also includes raw data and metadata)
-  publish_dir_mode = "link" // method for creating publish directory.  Default here for hardlink
-
-  // can be set to the path of a local gtf and fasta
-  ref_fasta = null
-  ref_gtf = null
-
-  /*
-  DEBUG parameters, should NOT be overwritten for production processing runs
-  */
   genomeSubsample = 5 // Subsamples the reference fasta and gtf to a single sequence (often representing a single chromosome)
   truncateTo = 300 // Subsamples the raw reads files to the specified number of reads for EACH raw reads file.
-  limitSamplesTo = false // Limits the number of samples to process.  This currently is incompatible with running the DESeq2 task which requires all samples 
-  stageLocal = true // Indicates if the raw read files should be staged for processing. Disabling is useful for checking the metadata staging without running any actual data processing.
-  skipVV = false // if true, VV will not be performed
-  force_single_end = false
 
-  multiqcConfig = "${projectDir}/config/modules/multiqc.config"
-
-  quality {
-    rseqc_sample_count = 15000000
-  }
-
-  // Print help menu
-  // Should only be overridden at CLI
-  help = false
-
-  // For now, this particular is good for all organisms listed on the file.
 }

--- a/RNAseq/Workflow_Documentation/NF_RCP-F/workflow_code/NF_RCP-F_1.0.0/config/tests/test_glds48.config
+++ b/RNAseq/Workflow_Documentation/NF_RCP-F/workflow_code/NF_RCP-F_1.0.0/config/tests/test_glds48.config
@@ -4,42 +4,12 @@ params {
   Parameters that MUST be supplied
   */
   gldsAccession = 'GLDS-48' // GeneLab Data Accession Number, e.g. GLDS-104
-  ensemblVersion = 96 // ensembl version to use for reference genome, should work as far back as ensembl 80, TODO: replace with source non-specific name
-  ref_source = 'ensembl' // designates the source of the reference files, e.g. ensembl, ensembl_plants
   use_dummy_gene_counts = true // Use random gene counts for Deseq2, this addresses an issue where low/zero gene counts causes DGE analysis to fail
-  
-  /*
-  Parameters that CAN be overwritten
-  */
-  runsheetPath = false
-  referenceStorePath = './References' // dicates where the reference fasta, gtf, these are shared across processing runs
-  derivedStorePath = './DerivedReferences' // dicates where the derived references files such as built index files are stored, shared across processing runs
-  outputDir = "." // the location for the output from the pipeline (also includes raw data and metadata)
-  publish_dir_mode = "link" // method for creating publish directory.  Default here for hardlink
-
-  // can be set to the path of a local gtf and fasta
-  ref_fasta = null
-  ref_gtf = null
 
   /*
   DEBUG parameters, should NOT be overwritten for production processing runs
   */
   genomeSubsample = 19 // Subsamples the reference fasta and gtf to a single sequence (often representing a single chromosome)
   truncateTo = 600 // Subsamples the raw reads files to the specified number of reads for EACH raw reads file.
-  limitSamplesTo = false // Limits the number of samples to process.  This currently is incompatible with running the DESeq2 task which requires all samples 
-  stageLocal = true // Indicates if the raw read files should be staged for processing. Disabling is useful for checking the metadata staging without running any actual data processing.
-  skipVV = false // if true, VV will not be performed
-  force_single_end = false
 
-  multiqcConfig = "${projectDir}/config/modules/multiqc.config"
-
-  quality {
-    rseqc_sample_count = 15000000
-  }
-
-  // Print help menu
-  // Should only be overridden at CLI
-  help = false
-
-  // For now, this particular is good for all organisms listed on the file.
 }

--- a/RNAseq/Workflow_Documentation/NF_RCP-F/workflow_code/NF_RCP-F_1.0.0/config/tests/test_nonGLDS.config
+++ b/RNAseq/Workflow_Documentation/NF_RCP-F/workflow_code/NF_RCP-F_1.0.0/config/tests/test_nonGLDS.config
@@ -4,7 +4,6 @@ params {
   Parameters that MUST be supplied
   */
   gldsAccession = 'CustomAnalysis' // GeneLab Data Accession Number, e.g. GLDS-104
-  ensemblVersion = 96 // ensembl version to use for reference genome, should work as far back as ensembl 80, TODO: replace with source non-specific name
   use_dummy_gene_counts = true // Use random gene counts for Deseq2, this addresses an issue where low/zero gene counts causes DGE analysis to fail
   
   /*

--- a/RNAseq/Workflow_Documentation/NF_RCP-F/workflow_code/NF_RCP-F_1.0.0/main.nf
+++ b/RNAseq/Workflow_Documentation/NF_RCP-F/workflow_code/NF_RCP-F_1.0.0/main.nf
@@ -86,7 +86,11 @@ println "Storing any newly generated derived reference files here: ${params.deri
 // Get all params sourced data into channels
 // Set up channel containing glds accession number
 if ( params.gldsAccession ) {ch_glds_accession = Channel.from( params.gldsAccession )} else { exit 1, "Missing Required Parameter: gldsAccession. Example for setting on CLI: --gldsAccession GLDS-194"}
-if ( !params.ensemblVersion ) { exit 1, "Missing Required Parameter: ensemblVersion. Example for setting on CLI: --ensemblVersion 96" }
+
+// Check conditionally required parameter (if using direct fasta, an ensemblVersion must also be supplied)
+if ( params.ref_fasta ) {
+  if ( !params.ensemblVersion ) { exit 1, "Missing Required Parameter: ensemblVersion. Example for setting on CLI: --ensemblVersion 96" }
+}
 
 if ( !params.outputDir ) {  params.outputDir = "$workflow.launchDir" }
 


### PR DESCRIPTION
fixes bug that prevented intended approach 1 launch

also updated test configs to remove extra parameters: 
these had masked a CLI bug regarding incorrectly requiring parameters that is now patched