### PR TITLE
Update to dp_tools 1.1.1 and Improve-storage-efficiency

### DIFF
--- a/RNAseq/Pipeline_GL-DPPD-7101_Versions/GL-DPPD-7101-F.md
+++ b/RNAseq/Pipeline_GL-DPPD-7101_Versions/GL-DPPD-7101-F.md
@@ -113,7 +113,7 @@ The DESeq2 Normalization and DGE step, [step 9](#9-normalize-read-counts-perform
 |DESeq2|1.34|[https://bioconductor.org/packages/release/bioc/html/DESeq2.html](https://bioconductor.org/packages/release/bioc/html/DESeq2.html)|
 |tximport|1.22|[https://bioconductor.org/packages/release/bioc/html/tximport.html](https://bioconductor.org/packages/release/bioc/html/tximport.html)|
 |tidyverse|1.3.1|[https://www.tidyverse.org](https://www.tidyverse.org)|
-|dp_tools|1.1.0|[https://github.com/J-81/dp_tools](https://github.com/J-81/dp_tools)|
+|dp_tools|1.1.1|[https://github.com/J-81/dp_tools](https://github.com/J-81/dp_tools)|
 |singularity|3.9|[https://sylabs.io/](https://sylabs.io/)|
 
 ---

--- a/RNAseq/Workflow_Documentation/NF_RCP-F/workflow_code/NF_RCP-F_1.0.0/config/software/by_docker_image.config
+++ b/RNAseq/Workflow_Documentation/NF_RCP-F/workflow_code/NF_RCP-F_1.0.0/config/software/by_docker_image.config
@@ -44,11 +44,11 @@ process {
     }
 
     withName: 'RNASEQ_RUNSHEET_FROM_GLDS|GENERATE_MD5SUMS|UPDATE_ISA_TABLES|SOFTWARE_VERSIONS' {
-        container = "quay.io/j_81/dp_tools:1.1.0"
+        container = "quay.io/j_81/dp_tools:1.1.1"
     }
 
     withLabel: 'VV' {
-        container = "quay.io/j_81/dp_tools:1.1.0"
+        container = "quay.io/j_81/dp_tools:1.1.1"
     }
     
     withName: 'GET_MAX_READ_LENGTH|ASSESS_STRANDEDNESS' {

--- a/RNAseq/Workflow_Documentation/NF_RCP-F/workflow_code/NF_RCP-F_1.0.0/modules/quality.nf
+++ b/RNAseq/Workflow_Documentation/NF_RCP-F/workflow_code/NF_RCP-F_1.0.0/modules/quality.nf
@@ -80,9 +80,9 @@ process TRIMGALORE {
 
     # rename with _trimmed suffix
     ${ meta.paired_end ? \
-      "cp ${ meta.id }_R1_raw_val_1.fq.gz ${ meta.id }_R1_trimmed.fastq.gz; \
-      cp ${ meta.id }_R2_raw_val_2.fq.gz ${ meta.id }_R2_trimmed.fastq.gz" : \
-      "cp ${ meta.id }_raw_trimmed.fq.gz ${ meta.id }_trimmed.fastq.gz"}
+      "mv ${ meta.id }_R1_raw_val_1.fq.gz ${ meta.id }_R1_trimmed.fastq.gz; \
+      mv ${ meta.id }_R2_raw_val_2.fq.gz ${ meta.id }_R2_trimmed.fastq.gz" : \
+      "mv ${ meta.id }_raw_trimmed.fq.gz ${ meta.id }_trimmed.fastq.gz"}
 
     trim_galore -v > versions.txt
     echo cutadapt version:\$(cutadapt --version) >> versions.txt


### PR DESCRIPTION
Update to dp_tools 1.1.1 which includes fixes to runsheet generation

thanks to @AstrobioMike for identification

this prevents a doubling of storage for this task