### PR TITLE
fix: normalize channel io across different reference file routes

### DIFF
--- a/RNAseq/Workflow_Documentation/NF_RCP-F/workflow_code/NF_RCP-F_1.0.0/references.nf
+++ b/RNAseq/Workflow_Documentation/NF_RCP-F/workflow_code/NF_RCP-F_1.0.0/references.nf
@@ -81,9 +81,9 @@ workflow references{
       // SUBSAMPLING STEP : USED FOR DEBUG/TEST RUNS
       if ( params.genomeSubsample ) {
         SUBSAMPLE_GENOME( genome_annotations_pre_subsample, organism_sci, ch_ref_source_version )
-        SUBSAMPLE_GENOME.out.build | set { genome_annotations_pre_ercc }
+        SUBSAMPLE_GENOME.out.build | flatten | toList | set { genome_annotations_pre_ercc }
       } else {
-        genome_annotations_pre_subsample | set { genome_annotations_pre_ercc }
+        genome_annotations_pre_subsample | flatten | toList | set { genome_annotations_pre_ercc }
       }
 
       // ERCC STEP : ADD ERCC Fasta and GTF to genome files


### PR DESCRIPTION
prior: running a non-subsampled run with uncached reference files caused an input mismatch for the BUILD_RSEM/BUILD_STAR processes

this flatten toList should normalize the branching routes into "genome_annotations_pre_ercc"